### PR TITLE
Change type of `args` inputs to `execute_function_for_effects` to make it more flexible

### DIFF
--- a/language/move-compiler/src/attr_derivation/evm_deriver.rs
+++ b/language/move-compiler/src/attr_derivation/evm_deriver.rs
@@ -1,0 +1,60 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    attr_derivation::{
+        attr_params, find_attr_slice, new_attr, new_native_fun, new_simple_type, new_var,
+    },
+    parser::ast::{FunctionName, ModuleDefinition, ModuleMember, Visibility},
+    shared::CompilationEnv,
+};
+use move_ir_types::location::sp;
+use move_symbol_pool::Symbol;
+
+const CONTRACT_ATTR: &str = "contract";
+const CALLABLE_ATTR: &str = "callable";
+const EXTERNAL_ATTR: &str = "external";
+
+pub(crate) fn derive_for_evm(_env: &mut CompilationEnv, mod_def: &mut ModuleDefinition) {
+    if find_attr_slice(&mod_def.attributes, CONTRACT_ATTR).is_none() {
+        // Not an EVM contract module
+        return;
+    }
+    let mut new_funs = vec![];
+    for mem in &mod_def.members {
+        if let ModuleMember::Function(fun_def) = mem {
+            if let Some(attr) = find_attr_slice(&fun_def.attributes, CALLABLE_ATTR) {
+                // Generate a `call_<name>(contract: address, <args>)` native function for
+                // cross contract calls.
+                let loc = attr.loc;
+                let call_name =
+                    FunctionName(sp(loc, Symbol::from(format!("call_{}", fun_def.name))));
+                let mut sign = fun_def.signature.clone();
+                sign.parameters.insert(
+                    0,
+                    (new_var(loc, "_target"), new_simple_type(loc, "address")),
+                );
+                // Create new #[external(params)] attribute, taking over parameters given to
+                // #[callable].
+                let attrs = sp(
+                    loc,
+                    vec![new_attr(
+                        loc,
+                        EXTERNAL_ATTR,
+                        attr_params(attr).into_iter().cloned().collect(),
+                    )],
+                );
+                new_funs.push(new_native_fun(
+                    loc,
+                    call_name,
+                    attrs,
+                    Visibility::Public(loc),
+                    sign,
+                ));
+            }
+        }
+    }
+    for fun_def in new_funs {
+        mod_def.members.push(ModuleMember::Function(fun_def))
+    }
+}

--- a/language/move-compiler/src/attr_derivation/mod.rs
+++ b/language/move-compiler/src/attr_derivation/mod.rs
@@ -1,0 +1,114 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    attr_derivation::evm_deriver::derive_for_evm,
+    parser::ast::{
+        Attribute, AttributeValue, Attribute_, Attributes, Function, FunctionBody_, FunctionName,
+        FunctionSignature, ModuleDefinition, NameAccessChain, NameAccessChain_, Type, Type_, Var,
+        Visibility,
+    },
+    shared::{CompilationEnv, Name},
+};
+use move_ir_types::location::{sp, Loc};
+use move_symbol_pool::Symbol;
+
+mod evm_deriver;
+
+const EVM_FLAVOR: &str = "evm";
+
+/// Entry point for deriving definitions from attributes for the given module. Depending on the
+/// flavor specified via the flags, this is dispatching to the according attribute processor.
+pub fn derive_from_attributes(env: &mut CompilationEnv, mod_def: &mut ModuleDefinition) {
+    if env.flags().get_flavor() == EVM_FLAVOR {
+        derive_for_evm(env, mod_def)
+    }
+}
+
+// ==========================================================================================
+// Helper Functions for analyzing attributes and creating the AST
+
+/// Helper function to find an attribute by name.
+pub fn find_attr<'a>(attrs: &'a Attributes, name: &str) -> Option<&'a Attribute> {
+    attrs
+        .value
+        .iter()
+        .find(|a| a.value.attribute_name().value.as_str() == name)
+}
+
+/// Helper function to find an attribute in a slice.
+pub fn find_attr_slice<'a>(vec: &'a [Attributes], name: &str) -> Option<&'a Attribute> {
+    for attrs in vec {
+        if let Some(a) = find_attr(attrs, name) {
+            return Some(a);
+        }
+    }
+    None
+}
+
+/// Helper to extract the parameters of an attribute. If the attribute is of the form
+/// `n(a1, ..., an)`, this extracts the a_i as a vector. Otherwise the attribute is assumed
+/// to have no parameters.
+pub fn attr_params(attr: &Attribute) -> Vec<&Attribute> {
+    match &attr.value {
+        Attribute_::Parameterized(_, vs) => vs.value.iter().collect(),
+        _ => vec![],
+    }
+}
+
+/// Helper to extract a named value attribute, as in `n [= v]`.
+#[allow(unused)]
+pub fn attr_value(attr: &Attribute) -> Option<(&Name, Option<&AttributeValue>)> {
+    match &attr.value {
+        Attribute_::Name(n) => Some((n, None)),
+        Attribute_::Assigned(n, v) => Some((n, Some(&*v))),
+        _ => None,
+    }
+}
+
+/// Creates a new attribute.
+pub fn new_attr(loc: Loc, name: &str, params: Vec<Attribute>) -> Attribute {
+    let n = sp(loc, Symbol::from(name));
+    if params.is_empty() {
+        sp(loc, Attribute_::Name(n))
+    } else {
+        sp(loc, Attribute_::Parameterized(n, sp(loc, params)))
+    }
+}
+
+/// Helper to create a new native function declaration.
+pub fn new_native_fun(
+    loc: Loc,
+    name: FunctionName,
+    attributes: Attributes,
+    visibility: Visibility,
+    signature: FunctionSignature,
+) -> Function {
+    Function {
+        attributes: vec![attributes],
+        loc,
+        visibility,
+        signature,
+        acquires: vec![],
+        name,
+        body: sp(loc, FunctionBody_::Native),
+    }
+}
+
+/// Helper to create a new named variable.
+pub fn new_var(loc: Loc, name: &str) -> Var {
+    Var(sp(loc, Symbol::from(name)))
+}
+
+/// Helper to create a new type, based on its simple name.
+pub fn new_simple_type(loc: Loc, ty_str: &str) -> Type {
+    sp(
+        loc,
+        Type_::Apply(Box::new(new_simple_name(loc, ty_str)), vec![]),
+    )
+}
+
+/// Helper to create a simple name.
+pub fn new_simple_name(loc: Loc, name: &str) -> NameAccessChain {
+    sp(loc, NameAccessChain_::One(sp(loc, Symbol::from(name))))
+}

--- a/language/move-compiler/src/command_line/mod.rs
+++ b/language/move-compiler/src/command_line/mod.rs
@@ -22,6 +22,8 @@ pub const SOURCE_MAP_SHORT: char = 'm';
 pub const TEST: &str = "test";
 pub const TEST_SHORT: char = 't';
 
+pub const FLAVOR: &str = "flavor";
+
 pub const COLOR_MODE_ENV_VAR: &str = "COLOR_MODE";
 
 pub const MOVE_COMPILED_INTERFACES_DIR: &str = "mv_interfaces";

--- a/language/move-compiler/src/lib.rs
+++ b/language/move-compiler/src/lib.rs
@@ -6,6 +6,7 @@
 #[macro_use(sp)]
 extern crate move_ir_types;
 
+mod attr_derivation;
 pub mod cfgir;
 pub mod command_line;
 pub mod compiled_unit;

--- a/language/move-compiler/src/parser/syntax.rs
+++ b/language/move-compiler/src/parser/syntax.rs
@@ -10,6 +10,7 @@ use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 
 use crate::{
+    attr_derivation::derive_from_attributes,
     diag,
     diagnostics::{Diagnostic, Diagnostics},
     parser::{ast::*, lexer::*},
@@ -2271,14 +2272,19 @@ fn parse_module(
         start_loc,
         context.tokens.previous_end_loc(),
     );
-    Ok(ModuleDefinition {
+    let mut def = ModuleDefinition {
         attributes,
         loc,
         address,
         name,
         is_spec_module,
         members,
-    })
+    };
+
+    // Run attribute derivation.
+    derive_from_attributes(context.env, &mut def);
+
+    Ok(def)
 }
 
 //**************************************************************************************************

--- a/language/move-compiler/tests/move_check/flavors/evm/derive.exp
+++ b/language/move-compiler/tests/move_check/flavors/evm/derive.exp
@@ -1,0 +1,9 @@
+error[E02001]: duplicate declaration, item, or annotation
+   ┌─ tests/move_check/flavors/evm/derive.move:11:7
+   │
+11 │     #[callable]
+   │       ^^^^^^^^ Duplicate module member or alias 'call_expect_duplicate'. Top level names in a namespace must be unique
+   ·
+14 │     fun call_expect_duplicate(_c: address) { }
+   │         --------------------- Alias previously defined here
+

--- a/language/move-compiler/tests/move_check/flavors/evm/derive.move
+++ b/language/move-compiler/tests/move_check/flavors/evm/derive.move
@@ -1,0 +1,15 @@
+#[contract]
+module 0x1::M {
+
+    #[callable]
+    fun add(x: u64): u64 { x + 1 }
+
+    fun expect_can_call(x: u64): u64 {
+        0x1::M::call_add(@1, x) + call_add(@2, x)
+    }
+
+    #[callable]
+    fun expect_duplicate(x: u64): u64 { x + 1 }
+
+    fun call_expect_duplicate(_c: address) { }
+}

--- a/language/move-compiler/tests/move_check_testsuite.rs
+++ b/language/move-compiler/tests/move_check_testsuite.rs
@@ -18,6 +18,9 @@ const KEEP_TMP: &str = "KEEP";
 
 const TEST_EXT: &str = "unit_test";
 
+/// Root of tests which require to set flavor flags.
+const FLAVOR_PATH: &str = "flavors/";
+
 fn default_testing_addresses() -> BTreeMap<String, NumericalAddress> {
     let mapping = [
         ("Std", "0x1"),
@@ -56,7 +59,23 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
 
     let exp_path = path.with_extension(EXP_EXT);
     let out_path = path.with_extension(OUT_EXT);
-    run_test(path, &exp_path, &out_path, Flags::empty())?;
+
+    let mut flags = Flags::empty();
+    match path.to_str() {
+        Some(p) if p.contains(FLAVOR_PATH) => {
+            // Extract the flavor from the path. Its the directory name of the file.
+            let flavor = path
+                .parent()
+                .expect("has parent")
+                .file_name()
+                .expect("has name")
+                .to_string_lossy()
+                .to_string();
+            flags = flags.set_flavor(flavor)
+        }
+        _ => {}
+    };
+    run_test(path, &exp_path, &out_path, flags)?;
     Ok(())
 }
 

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::borrow::Borrow;
+
 use crate::{data_cache::TransactionDataCache, runtime::VMRuntime};
 use move_binary_format::errors::*;
 use move_core_types::{
@@ -90,14 +92,17 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     /// NOTE: The ability to deserialize `args` into arbitrary types is very powerful--e.g., it can
     /// used to manufacture `signer`'s or `Coin`'s from raw bytes. It is the respmsibility of the
     /// caller (e.g. adapter) to ensure that this power is useed responsibility/securely for its use-case.
-    pub fn execute_function_for_effects(
+    pub fn execute_function_for_effects<V>(
         mut self,
         module: &ModuleId,
         function_name: &IdentStr,
         ty_args: Vec<TypeTag>,
-        args: Vec<Vec<u8>>,
+        args: Vec<V>,
         gas_status: &mut GasStatus,
-    ) -> ExecutionResult {
+    ) -> ExecutionResult
+    where
+        V: Borrow<[u8]>,
+    {
         let gas_budget = gas_status.remaining_gas().get();
         let execution_res = self.runtime.execute_function_for_effects(
             module,


### PR DESCRIPTION
## Motivation

Currently function to enter VM execution take fully owned vectors of `[u8]` only to promptly deserialize them and drop the vectors. This requires VM users to continuously clone, and live with endless allocations / deallocations. 

The solution is to make the `args` input to `execute_function_for_effects` into an `args: Vec<V>`, with `V` being a generic type with `V: Borrow<[u8]>`. And fix called functions to do the same. This is purely a change of type and an addition of `.borrow()` to get a reference when needed, no other functionality changes. 

As a result, those who enjoy passing `Vec<u8>`s around can continue to do so, while others can pass in types that provide a &[u8] without allocations.

### Have you read the [Contributing Guidelines on pull requests]

Yes.

## Test Plan

All tests pass.
